### PR TITLE
Add 1x3 layout to concat node

### DIFF
--- a/nodes_py/image_concat_node.py
+++ b/nodes_py/image_concat_node.py
@@ -13,7 +13,7 @@ class ConcatImages:
                 "image1": ("IMAGE",),
                 "image2": ("IMAGE",),
                 "background_color": ("STRING", {"default": "#000000"}),
-                "layout": (["1*4", "2*2"], {"default": "2*2"}),
+                "layout": (["1*4", "1*3", "2*2"], {"default": "2*2"}),
             },
             "optional": {
                 "image3": ("IMAGE",),
@@ -63,6 +63,14 @@ class ConcatImages:
             count = min(len(pil_images), 4)
             new_im = Image.new('RGB', (max_w * count, max_h), color=bg_color)
             for idx in range(count):
+                img = pil_images[idx]
+                mask = img if img.mode in ("RGBA", "LA") else None
+                new_im.paste(img, (max_w * idx, 0), mask)
+        elif layout == "1*3":
+            if image3 is None or image4 is not None:
+                raise ValueError("Layout '1*3' requires image3 and no image4")
+            new_im = Image.new('RGB', (max_w * 3, max_h), color=bg_color)
+            for idx in range(3):
                 img = pil_images[idx]
                 mask = img if img.mode in ("RGBA", "LA") else None
                 new_im.paste(img, (max_w * idx, 0), mask)


### PR DESCRIPTION
## Summary
- expand layout options list with `1*3`
- implement new `1*3` branch requiring `image3` while `image4` must be empty

## Testing
- `python -m py_compile nodes_py/image_concat_node.py`


------
https://chatgpt.com/codex/tasks/task_e_68637f830184832fa0a4b864a1af678a